### PR TITLE
Include headers in led_blaster.cpp and notebook_adapter.cpp

### DIFF
--- a/led_blaster.cpp
+++ b/led_blaster.cpp
@@ -8,6 +8,8 @@
 
 #include <Arduino.h>
 
+#include "led_blaster.h"
+
 namespace LedBlaster {
   uint16_t led_on_ms;
   uint16_t led_off_ms;

--- a/led_blaster.cpp
+++ b/led_blaster.cpp
@@ -14,6 +14,11 @@ namespace LedBlaster {
   uint16_t led_on_ms;
   uint16_t led_off_ms;
 
+  void setup() {
+    pinMode(LED_PIN, OUTPUT);
+    enable_fast_mode(false);
+  }
+
   void enable_fast_mode(bool fast_mode_enabled) {
     if (fast_mode_enabled) {
       led_on_ms = LED_ON_MS_FAST;
@@ -22,11 +27,6 @@ namespace LedBlaster {
       led_on_ms = LED_ON_MS_NORMAL;
       led_off_ms = LED_OFF_MS_NORMAL;
     }
-  }
-
-  void setup() {
-    pinMode(LED_PIN, OUTPUT);
-    enable_fast_mode(false);
   }
 
   void emit_0() {

--- a/notebook_adapter.cpp
+++ b/notebook_adapter.cpp
@@ -6,7 +6,9 @@
 #define DATA_MODE_TIMEOUT_MS 1000
 
 #include <Arduino.h>
+
 #include "led_blaster.h"
+#include "notebook_adapter.h"
 
 namespace NotebookAdapter {
   unsigned long last_data_ms = 0;


### PR DESCRIPTION
Fixes https://github.com/synthead/timex-datalink-arduino/issues/11!

This project is small enough that it compiled well without the .cpp files including their own header files, and I simply forgot to include them :joy:  This PR includes the headers for the .cpp files :ok_hand: 