### PR TITLE
Call NotebookAdapter::emulate before LedBlaster::emit_byte

### DIFF
--- a/timex-datalink-arduino.ino
+++ b/timex-datalink-arduino.ino
@@ -10,7 +10,7 @@ void loop() {
   int serial_byte = Serial.read();
 
   if (serial_byte != -1) {
-    LedBlaster::emit_byte(serial_byte);
     NotebookAdapter::emulate(serial_byte);
+    LedBlaster::emit_byte(serial_byte);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/synthead/timex-datalink-arduino/issues/14!

Small PR to call `NotebookAdapter::emulate` before `LedBlaster::emit_byte` in `timex-datalink-arduino.ino`'s `loop`.

From https://github.com/synthead/timex-datalink-arduino/issues/14:

> In `timex-datalink-arduino.ino`'s `loop` function, `LedBlaster::emit_byte` is called before `NotebookAdapter::emulate`:
> 
> https://github.com/synthead/timex-datalink-arduino/blob/7bd69af66ec4b40607eb50097a1327bd94362fa4/timex-datalink-arduino.ino#L9-L16
> 
> `NotebookAdapter::emulate` occasionally reaches back to `LedBlaster` functions to switch modes:
> 
> https://github.com/synthead/timex-datalink-arduino/blob/7bd69af66ec4b40607eb50097a1327bd94362fa4/notebook_adapter.cpp#L17-L46
> 
> So it'd make sense to call `NotebookAdapter::emulate` before calling `LedBlaster::emit_byte`, even if the adapter functionally works right now