### PR TITLE
Support the Raspberry Pi Pico

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project is not dependent on any specific Arduino board, although it has bee
 - [Teensy LC](https://www.pjrc.com/teensy/teensyLC.html)
 - [Raspberry Pi Pico](https://www.raspberrypi.com/products/raspberry-pi-pico)
 
-These boards have USB serial and an onboard LED, so they can be used as-is without any external components:
+These boards have USB serial interfaces and onboard LEDs, so they can be used as-is without any external components:
 
 ![image](https://user-images.githubusercontent.com/820984/187859185-94f02df7-64f5-4bb3-bf00-12621f5f3b38.png)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ This Notebook Adapter emulator is tested to be compatible with:
 - [DSI Electronics e-BRAIN v1.1.6](https://archive.org/details/ebrain-1.1.6)
 - [timex\_datalink\_client Ruby library](https://github.com/synthead/timex_datalink_client)
 
-This project is not dependent on any specific Arduino board, although it is designed with the [Teensy LC](https://www.pjrc.com/teensy/teensyLC.html) in mind.  The Teensy LC has USB serial and an onboard LED, so the board can be used as-is without any external components:
+This project is not dependent on any specific Arduino board, although it has been tested to work with these devices:
+
+- [Teensy LC](https://www.pjrc.com/teensy/teensyLC.html)
+- [Raspberry Pi Pico](https://www.raspberrypi.com/products/raspberry-pi-pico)
+
+These boards have USB serial and an onboard LED, so they can be used as-is without any external components:
 
 ![image](https://user-images.githubusercontent.com/820984/187859185-94f02df7-64f5-4bb3-bf00-12621f5f3b38.png)
 

--- a/led_blaster.cpp
+++ b/led_blaster.cpp
@@ -1,4 +1,4 @@
-#define LED_PIN 13
+#define LED_PIN LED_BUILTIN
 
 #define LED_ON_MS_NORMAL 15
 #define LED_OFF_MS_NORMAL 450

--- a/notebook_adapter.cpp
+++ b/notebook_adapter.cpp
@@ -26,7 +26,7 @@ namespace NotebookAdapter {
       case COMMAND_QUERY:
         if (command_mode) {
           Serial.print(COMMAND_QUERY_PAYLOAD);
-          Serial.write(0);
+          Serial.write((byte)0);
         }
 
         break;


### PR DESCRIPTION
Closes https://github.com/synthead/timex-datalink-arduino/issues/16!

This PR adds support for the Raspberry Pi Pico!  The changes are backward-compatible with the Teensy LC, and no special header checks need to be done!  This is tested working with a real Raspberry Pi Pico using the onboard LED.

Please note that the LED is significantly dimmer than the LC's LED, so it must be held much closer to the optical sensor to work.  An external LED would mitigate this issue, of course.